### PR TITLE
Kirby v4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		}
 	],
 	"require": {
-		"getkirby/cms": "^3.7",
+		"getkirby/cms": "^3.7|^4.0",
 		"getkirby/composer-installer": "^1.2"
 	},
 	"extra": {


### PR DESCRIPTION
Allow the plugin to be installed in Kirby v4. Haven't had any issues yet with the alpha.